### PR TITLE
Bump the version to 0.1.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(
     name="jgscm",
     description="Jupyter Google Cloud Storage ContentsManager",
-    version="0.1.8",
+    version="0.1.9",
     license="MIT",
     author="Vadim Markovtsev",
     author_email="vadim@sourced.tech",


### PR DESCRIPTION
Hi there -- I tried out JupyterLab on Dataproc and got 404 errors using jgscm version 0.1.8. If I understand correctly the 404 issue was already fixed in #9 (at least it worked for me!). Can you please upload this as a version to PyPi when you get a chance?

Linking this to https://github.com/GoogleCloudPlatform/dataproc-initialization-actions/issues/238